### PR TITLE
Framework E (17.104.x): Java 21 / WildFly 32 / Jakarta EE 10 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 - Remove redundant profile from `pom.xml`
 - Github migration to HMCTS Organisation
 
+## [21.0.0-SNAPSHOT] - 2026-03-26
+### Changed
+- Upgraded to Java 21 and Jakarta EE 10
+- Bumped version number to `21.0.0-SNAPSHOT`
+
 ## [17.0.0] - 2023-05-05
 ### Changed
 - Release of Java 17 version

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals centos8-j17-postgres
+    - identifier -equals ubuntu-j21
  
 variables:
   - name: sonarqubeProject

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.justice</groupId>
     <artifactId>maven-super-pom</artifactId>
-    <version>21.0.0-SNAPSHOT</version>
+    <version>21.0.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Maven Super Pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.justice</groupId>
     <artifactId>maven-super-pom</artifactId>
-    <version>17.0.1-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Maven Super Pom</name>


### PR DESCRIPTION
## Summary
Upgrades `cp-maven-super-pom` to Java 21 as part of the Framework E (17.104.x) release line backport of the Java 21 / WildFly 32 / Jakarta EE 10 upgrade.

## Related
Framework E docs and status: https://github.com/hmcts/java-21-wildfly-32-updgrade-pilot-cpp-framework