### PR TITLE
Update CHANGELOG for 21.0.0-M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,8 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
-- Add license file
-- Update README.md to include versioning strategy
-- Remove redundant profile from `pom.xml`
-- Github migration to HMCTS Organisation
 
-## [21.0.0-M1] - 2026-06-01
+## [21.0.0-M2] - 2026-06-02
 ### Changed
 - Upgraded to Java 21; enforced minimum JVM version 21 via Maven enforcer
 - Bumped version to `21.0.0-M1` for the 17.104.x Java 21 release line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 - Remove redundant profile from `pom.xml`
 - Github migration to HMCTS Organisation
 
-## [21.0.0-SNAPSHOT] - 2026-03-26
+## [21.0.0-M1] - 2026-06-01
 ### Changed
-- Upgraded to Java 21 and Jakarta EE 10
-- Bumped version number to `21.0.0-SNAPSHOT`
+- Upgraded to Java 21; enforced minimum JVM version 21 via Maven enforcer
+- Bumped version to `21.0.0-M1` for the 17.104.x Java 21 release line
 
 ## [17.0.0] - 2023-05-05
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.justice</groupId>
     <artifactId>maven-super-pom</artifactId>
-    <version>21.0.0-M1</version>
+    <version>21.0.0-M2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Maven Super Pom</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.gov.justice</groupId>
     <artifactId>maven-super-pom</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>21.0.0-M1</version>
     <packaging>pom</packaging>
 
     <name>Maven Super Pom</name>


### PR DESCRIPTION
Replaces the stale Framework F spike entry with the accurate 21.0.0-M1 changelog for this release line.